### PR TITLE
Repo Display and New Repo Form

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,3 +1,34 @@
 body {
   background: lime;
 }
+
+.repo-card, .tag-body, .repo-details {
+  display: flex;
+}
+
+.repo-card {
+  background: rgb(24, 24, 24);
+  color: rgb(67, 147, 250);
+  flex-direction: row;
+}
+
+.repo-tag {
+  padding: 0.5rem 1rem;
+  background: rgb(63, 63, 99);
+  border-radius: 1rem;
+  margin: 1px;
+}
+
+.repo-left {
+  width: 75%;
+}
+
+.repo-right {
+  width: 20%;
+  display: flex;
+  flex-direction: column;
+}
+
+.repo-details {
+  gap: 3px;
+}

--- a/main.js
+++ b/main.js
@@ -153,9 +153,69 @@ const renderProjects = (array) =>{
   renderToDom("#display-body", reference)
 }
 
-const repoHTML = (repos = user.repositories) => {
+const renderRepos = (repos = user.repositories) => {
   let htmlString = ""
+  repos.map(repo => {
+    htmlString += `<div class="card repo-card">
+                    <div class="repo-left">
+                      <div class="card-body">
+                        <h5 class="card-title">${repo.name}</h5>
+                        <p class="card-text">${repo.description}</p>
+                        <div class="tag-body">`
+                          repo.tags.map(tag => {htmlString += `<div class="repo-tag">${tag}</div>`})
+          htmlString += `</div>
+                        <div class="repo-details">
+                          <div>${repo.language}</div>
+                          <div>${repo.favorites}</div>
+                          <div>${repo.forks}</div>`
+                          if (repo.license) {htmlString += `<div>${repo.license}</div>`}
+                          if (repo.issues > 0) {
+                            htmlString += `${repo.issues} ${repo.issues === 1 ? 'issue needs help' : 'issues need help'}`
+                          }
+            htmlString += `<div>Updated on ${repo.timestamp.toDateString()}</div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="repo-right">
+                      <button class="btn btn-outline-light" id="star--repositories--${repo.id}">Star</button>
+                      <button class="btn btn-outline-light" id="delete--repositories--${repo.id}">Delete</button>
+                    </div>
+                  </div>`
+  })
+  renderToDom("#display-body", htmlString)
+}
 
+const repoForm = () => {
+  const formDisplay = `<h5>Create a New Repository</h5>
+                      <input type="text" class="form-name" id="name" name="name" placeholder="Name" required>
+                      <input type ="text" class="form-description" id="description" name="description" placeholder="Description" required>
+                      <input type="text" class="form-description" name="tags" placeholder="Tags">
+                      <p>Add tags separated by commas (',')</p>
+                      <input type="text" name="language" placeholder="Primary Language (JavaScript, TypeScript, etc.)" required>
+                      <input type="text" name="license" placeholder="License">
+                      <button type="submit" class="btn" id="submit-btn">Create Repository</button>`
+  renderToDom("#submit-form", formDisplay)
+  document.querySelector("#submit-form").addEventListener("submit", (e) => {
+    e.preventDefault()
+    formData = new FormData(e.target)
+    const newRepo = {
+      id: user.repositories[user.repositories.length -1].id + 1,
+      name: formData.get('name'),
+      description: formData.get('description'),
+      tags: formData.get('tags').toLowerCase().split(',').map(tag => tag.trim()),
+      language: formData.get('language'),
+      favorites: 0,
+      forks: 0,
+      license: formData.get('license'),
+      issues: 0,
+      timestamp: new Date(),
+      star: false,
+    }
+    user.repositories.push(newRepo)
+    renderRepos()
+    document.querySelector("#submit-form").reset()
+    console.log("Submitted")
+  })
 }
 
 //function for Overview display currently all placeholder 
@@ -212,7 +272,8 @@ const startUp = () => {
   if (window.location.href.includes("index.html")) {
     renderOverview(deleteMe)
   } else if (window.location.href.includes("repos.html")) {
-
+    renderRepos()
+    repoForm()
   } else if (window.location.href.includes("projects.html")) {
     renderProjects(user.projects)
   } else if (window.location.href.includes("packages.html")) {

--- a/main.js
+++ b/main.js
@@ -266,8 +266,6 @@ const createPackage = (e) => {
   renderPackages(user.packages)
 }
 
-document.querySelector("#submit-package-form").addEventListener("submit", createPackage)
-
 const startUp = () => {
   if (window.location.href.includes("index.html")) {
     renderOverview(deleteMe)
@@ -278,6 +276,7 @@ const startUp = () => {
     renderProjects(user.projects)
   } else if (window.location.href.includes("packages.html")) {
     renderPackages(user.packages)
+    document.querySelector("#submit-package-form").addEventListener("submit", createPackage)
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -153,9 +153,69 @@ const renderProjects = (array) =>{
   renderToDom("#display-body", reference)
 }
 
-const repoHTML = (repos = user.repositories) => {
+const renderRepos = (repos = user.repositories) => {
   let htmlString = ""
+  repos.map(repo => {
+    htmlString += `<div class="card repo-card">
+                    <div class="repo-left">
+                      <div class="card-body">
+                        <h5 class="card-title">${repo.name}</h5>
+                        <p class="card-text">${repo.description}</p>
+                        <div class="tag-body">`
+                          repo.tags.map(tag => {htmlString += `<div class="repo-tag">${tag}</div>`})
+          htmlString += `</div>
+                        <div class="repo-details">
+                          <div>${repo.language}</div>
+                          <div>${repo.favorites}</div>
+                          <div>${repo.forks}</div>`
+                          if (repo.license) {htmlString += `<div>${repo.license}</div>`}
+                          if (repo.issues > 0) {
+                            htmlString += `${repo.issues} ${repo.issues === 1 ? 'issue needs help' : 'issues need help'}`
+                          }
+            htmlString += `<div>Updated on ${repo.timestamp.toDateString()}</div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="repo-right">
+                      <button class="btn btn-outline-light" id="star--repositories--${repo.id}">Star</button>
+                      <button class="btn btn-outline-light" id="delete--repositories--${repo.id}">Delete</button>
+                    </div>
+                  </div>`
+  })
+  renderToDom("#display-body", htmlString)
+}
 
+const repoForm = () => {
+  const formDisplay = `<h5>Create a New Repository</h5>
+                      <input type="text" class="form-name" id="name" name="name" placeholder="Name" required>
+                      <input type ="text" class="form-description" id="description" name="description" placeholder="Description" required>
+                      <input type="text" class="form-description" name="tags" placeholder="Tags">
+                      <p>Add tags separated by commas (',')</p>
+                      <input type="text" name="language" placeholder="Primary Language (JavaScript, TypeScript, etc.)" required>
+                      <input type="text" name="license" placeholder="License">
+                      <button type="submit" class="btn" id="submit-btn">Create Repository</button>`
+  renderToDom("#submit-form", formDisplay)
+  document.querySelector("#submit-form").addEventListener("submit", (e) => {
+    e.preventDefault()
+    formData = new FormData(e.target)
+    const newRepo = {
+      id: user.repositories[user.repositories.length -1].id + 1,
+      name: formData.get('name'),
+      description: formData.get('description'),
+      tags: formData.get('tags').toLowerCase().split(',').map(tag => tag.trim()),
+      language: formData.get('language'),
+      favorites: 0,
+      forks: 0,
+      license: formData.get('license'),
+      issues: 0,
+      timestamp: new Date(),
+      star: false,
+    }
+    user.repositories.push(newRepo)
+    renderRepos()
+    document.querySelector("#submit-form").reset()
+    console.log("Submitted")
+  })
 }
 
 //function for Overview display currently all placeholder 
@@ -179,7 +239,8 @@ const startUp = () => {
   if (window.location.href.includes("index.html")) {
     renderOverview(deleteMe)
   } else if (window.location.href.includes("repos.html")) {
-
+    renderRepos()
+    repoForm()
   } else if (window.location.href.includes("projects.html")) {
     renderProjects(user.projects)
   } else if (window.location.href.includes("packages.html")) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Repos and new repo form display on load of Repositories page
New repo will add to repos display on submission of form
Cursory styling of repositories
Moved packages EventListener to within startUp function (was erroring out on other pages)

## Related Issue
#12 & #20 
Also, found bug that threw error on load of pages other than "packages"

## Motivation and Context
Users can now view and add repositories

## How Can This Be Tested?
Fetch, run server, hard refresh
Navigate to repositories page, repos and form should appear
Fill in form fields and click 'Create Repository', new repository will appear in display, form will clear

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
